### PR TITLE
Raise an `ArgumentError` if `max_queue_size` is not positive

### DIFF
--- a/lib/boatload/async_batch_processor.rb
+++ b/lib/boatload/async_batch_processor.rb
@@ -31,6 +31,7 @@ module Boatload
     )
       raise ArgumentError, 'delivery_interval must not be negative' if delivery_interval.negative?
       raise ArgumentError, 'max_backlog_size must not be negative' if max_backlog_size.negative?
+      raise ArgumentError, 'max_queue_size must be positive' unless max_queue_size.positive?
       raise ArgumentError, 'You must give a block' unless block_given?
 
       @queue = Queue.new

--- a/test/boatload/async_batch_processor_test.rb
+++ b/test/boatload/async_batch_processor_test.rb
@@ -23,6 +23,12 @@ module Boatload
         end
       end
 
+      should 'raise if max_queue_size is not positive' do
+        assert_raises ArgumentError do
+          AsyncBatchProcessor.new(max_queue_size: 0) {}
+        end
+      end
+
       should 'not start worker and timer threads' do
         abp = AsyncBatchProcessor.new {}
 


### PR DESCRIPTION
A `max_queue_size` of 0 or less doesn't make any sense since
`AsyncBatchProcessor#push` will always raise a `QueueOverflow`.